### PR TITLE
Allow build failure propogation

### DIFF
--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -11,6 +11,15 @@ CHALLENGE_ID=$1
 RUBY_TEST_REPORT_CSV_FILE="${SCRIPT_CURRENT_DIR}/coverage/results.csv"
 RUBY_CODE_COVERAGE_INFO="${SCRIPT_CURRENT_DIR}/coverage.tdl"
 
+### Guard clause to check for invalid CHALLENGE_ID
+
+if [[ ! -e "${SCRIPT_CURRENT_DIR}/lib/solutions/${CHALLENGE_ID}" ]]; then
+   echo "" > ${RUBY_CODE_COVERAGE_INFO}
+   echo "The provided CHALLENGE_ID: '${CHALLENGE_ID}' isn't valid, aborting process..."
+   exit 1
+fi
+
+
 ( cd ${SCRIPT_CURRENT_DIR} && \
     bundle install && \
     bundle exec rake test || true 1>&2 )

--- a/get_coverage_for_challenge.sh
+++ b/get_coverage_for_challenge.sh
@@ -13,7 +13,7 @@ RUBY_CODE_COVERAGE_INFO="${SCRIPT_CURRENT_DIR}/coverage.tdl"
 
 ( cd ${SCRIPT_CURRENT_DIR} && \
     bundle install && \
-    bundle exec rake test 1>&2 || true )
+    bundle exec rake test || true 1>&2 )
 
 [ -e ${RUBY_CODE_COVERAGE_INFO} ] && rm ${RUBY_CODE_COVERAGE_INFO}
 


### PR DESCRIPTION
Cannot remove `|| true` from any of the lines as they return a non-zero exit code for failing tests when gathering coverage info.

Added a guard clause to catch the special case where which returns a non-zero exit code.

Linked to https://github.com/julianghionoiu/dpnt-coverage/pull/34 and issue https://github.com/julianghionoiu/dpnt-coverage/issues/35 